### PR TITLE
ODP-7157: Install superset-core non-editable before venv-pack

### DIFF
--- a/odp/buildtarball-from-source.sh
+++ b/odp/buildtarball-from-source.sh
@@ -274,6 +274,10 @@ print(f'{count} files in {assets}')
 ")
 echo "Frontend assets: ${STATIC_ASSETS}"
 
+# venv-pack does not support editable (-e) installs, so switch to a real install just before packaging
+pip uninstall -y apache-superset-core
+pip install --no-deps "${SUPERSET_SOURCE_ROOT}/superset-core"
+
 # Pack the virtual environment using venv-pack
 echo ""
 echo "Packing virtual environment into tarball ..."


### PR DESCRIPTION
In Superset `6.1.0`, the module `superset-core` has been newly added, and it was installed with the `-e` (editable) option, so `venv-pack` packaging refuses editable packages.
- Reinstall `superset-core` without the `-e` (editable) option before packaging.
- Local build successful
<img width="3796" height="1850" alt="image" src="https://github.com/user-attachments/assets/8625c977-77a3-42f2-90d1-2d5529706985" />
