### PR TITLE
OSV-23700 - CVE - Bumped-up pyasn1 to 0.6.3 to address CVE-2026-23490/CVE-2026-30922

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -279,7 +279,7 @@ prompt-toolkit==3.0.51
     # via click-repl
 pyarrow==16.1.0
     # via apache-superset (pyproject.toml)
-pyasn1==0.6.1
+pyasn1==0.6.3
     # via
     #   pyasn1-modules
     #   rsa


### PR DESCRIPTION
- Component: superset (rel/ODP-3.3.6.4-1, release 3.3.6.4)
- Library: pyasn1 → 0.6.3
- Tickets: OSV-23700, OSV-23701
- Files: requirements/base.txt:pyasn1==0.6.3×1