### PR TITLE
OSV-23702 - CVE - Bumped-up idna to 3.15 to address CVE-2026-45409

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -165,7 +165,7 @@ holidays==0.82
     # via apache-superset (pyproject.toml)
 humanize==4.12.3
     # via apache-superset (pyproject.toml)
-idna==3.10
+idna==3.15
     # via
     #   email-validator
     #   requests


### PR DESCRIPTION
- Component: superset (rel/ODP-3.3.6.4-1, release 3.3.6.4)
- Library: idna → 3.15
- Tickets: OSV-23702
- Files: requirements/base.txt:idna==3.15×1