### PR TITLE
OSV-23705 - CVE - Bumped-up urllib3 to 2.7.0 to address CVE-2025-66418/CVE-2025-66471/CVE-2026-21441/CVE-2026-44431

### DIFF
--- a/requirements/base.in
+++ b/requirements/base.in
@@ -16,7 +16,7 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-urllib3==2.5.0
+urllib3==2.7.0
 werkzeug>=3.0.1
 numexpr>=2.9.0
 

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -412,7 +412,7 @@ tzdata==2025.2
     #   pandas
 url-normalize==2.2.1
     # via requests-cache
-urllib3==2.5.0
+urllib3==2.7.0
     # via
     #   -r requirements/base.in
     #   requests


### PR DESCRIPTION
- Component: superset (rel/ODP-3.3.6.4-1, release 3.3.6.4)
- Library: urllib3 → 2.7.0
- Tickets: OSV-23705, OSV-23706, OSV-23707, OSV-23708
- Files: requirements/base.txt:urllib3==2.7.0×1, requirements/base.in:urllib3==2.7.0×1