### PR TITLE
OSV-23709 - CVE - Bumped-up pyjwt to 2.12.0 to address CVE-2026-32597

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -289,7 +289,7 @@ pycparser==2.22
     # via cffi
 pygments==2.19.1
     # via rich
-pyjwt==2.10.1
+pyjwt==2.12.0
     # via
     #   apache-superset (pyproject.toml)
     #   flask-appbuilder


### PR DESCRIPTION
- Component: superset (rel/ODP-3.3.6.4-1, release 3.3.6.4)
- Library: pyjwt → 2.12.0
- Tickets: OSV-23709
- Files: requirements/base.txt:pyjwt==2.12.0×1