### PR TITLE
OSV-23724 - CVE - Bumped-up flask-cors to 6.0.0 to address CVE-2024-6839/CVE-2024-6844/CVE-2024-6866

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -120,7 +120,7 @@ flask-caching==2.3.1
     # via apache-superset (pyproject.toml)
 flask-compress==1.17
     # via apache-superset (pyproject.toml)
-flask-cors==4.0.2
+flask-cors==6.0.0
     # via apache-superset (pyproject.toml)
 flask-jwt-extended==4.7.1
     # via flask-appbuilder


### PR DESCRIPTION
- Component: superset (rel/ODP-3.3.6.4-1, release 3.3.6.4)
- Library: flask-cors → 6.0.0
- Tickets: OSV-23724, OSV-23725, OSV-23726
- Files: requirements/base.txt:flask-cors==6.0.0×1