### PR TITLE
OSV-23717 - CVE - Bumped-up brotli to 1.2.0 to address CVE-2025-6176

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -32,7 +32,7 @@ blinker==1.9.0
     # via flask
 bottleneck==1.5.0
     # via apache-superset (pyproject.toml)
-brotli==1.1.0
+brotli==1.2.0
     # via flask-compress
 cachelib==0.13.0
     # via


### PR DESCRIPTION
- Component: superset (rel/ODP-3.3.6.4-1, release 3.3.6.4)
- Library: brotli → 1.2.0
- Tickets: OSV-23717
- Files: requirements/base.txt:brotli==1.2.0×1