### PR TITLE
OSV-23718 - CVE - Bumped-up mako to 1.3.12 to address CVE-2026-41205/CVE-2026-44307

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -195,7 +195,7 @@ kombu==5.5.3
     # via celery
 limits==5.1.0
     # via flask-limiter
-mako==1.3.10
+mako==1.3.12
     # via
     #   apache-superset (pyproject.toml)
     #   alembic


### PR DESCRIPTION
- Component: superset (rel/ODP-3.3.6.4-1, release 3.3.6.4)
- Library: mako → 1.3.12
- Tickets: OSV-23718, OSV-23719
- Files: requirements/base.txt:mako==1.3.12×1