### PR TITLE
OSV-23720 - CVE - Bumped-up markdown to 3.8.1 to address CVE-2025-69534

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -199,7 +199,7 @@ mako==1.3.10
     # via
     #   apache-superset (pyproject.toml)
     #   alembic
-markdown==3.8
+markdown==3.8.1
     # via apache-superset (pyproject.toml)
 markdown-it-py==3.0.0
     # via rich


### PR DESCRIPTION
- Component: superset (rel/ODP-3.3.6.4-1, release 3.3.6.4)
- Library: markdown → 3.8.1
- Tickets: OSV-23720
- Files: requirements/base.txt:markdown==3.8.1×1