### PR TITLE
OSV-23721 - CVE - Bumped-up marshmallow to 3.26.2 to address CVE-2025-68480

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -209,7 +209,7 @@ markupsafe==3.0.2
     #   mako
     #   werkzeug
     #   wtforms
-marshmallow==3.26.1
+marshmallow==3.26.2
     # via
     #   apache-superset (pyproject.toml)
     #   flask-appbuilder


### PR DESCRIPTION
- Component: superset (rel/ODP-3.3.6.4-1, release 3.3.6.4)
- Library: marshmallow → 3.26.2
- Tickets: OSV-23721
- Files: requirements/base.txt:marshmallow==3.26.2×1