### PR TITLE
OSV-23722 - CVE - Bumped-up pygments to 2.20.0 to address CVE-2026-4539

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -287,7 +287,7 @@ pyasn1-modules==0.4.2
     # via google-auth
 pycparser==2.22
     # via cffi
-pygments==2.19.1
+pygments==2.20.0
     # via rich
 pyjwt==2.10.1
     # via


### PR DESCRIPTION
- Component: superset (rel/ODP-3.3.6.4-1, release 3.3.6.4)
- Library: pygments → 2.20.0
- Tickets: OSV-23722
- Files: requirements/base.txt:pygments==2.20.0×1