### PR TITLE
OSV-23723 - CVE - Bumped-up requests to 2.33.0 to address CVE-2026-25645

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -332,7 +332,7 @@ referencing==0.36.2
     # via
     #   jsonschema
     #   jsonschema-specifications
-requests==2.32.4
+requests==2.33.0
     # via
     #   requests-cache
     #   shillelagh


### PR DESCRIPTION
- Component: superset (rel/ODP-3.3.6.4-1, release 3.3.6.4)
- Library: requests → 2.33.0
- Tickets: OSV-23723
- Files: requirements/base.txt:requests==2.33.0×1