### PR TITLE
OSV-23733 - CVE - Bumped-up python-dotenv to 1.2.2 to address CVE-2026-28684

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -311,7 +311,7 @@ python-dateutil==2.9.0.post0
     #   holidays
     #   pandas
     #   shillelagh
-python-dotenv==1.1.0
+python-dotenv==1.2.2
     # via apache-superset (pyproject.toml)
 python-geohash==0.8.5
     # via apache-superset (pyproject.toml)


### PR DESCRIPTION
- Component: superset (rel/ODP-3.3.6.4-1, release 3.3.6.4)
- Library: python-dotenv → 1.2.2
- Tickets: OSV-23733
- Files: requirements/base.txt:python-dotenv==1.2.2×1