### PR TITLE
OSV-23734 - CVE - Bumped-up pynacl to 1.6.2 to address CVE-2025-69277

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -294,7 +294,7 @@ pyjwt==2.10.1
     #   apache-superset (pyproject.toml)
     #   flask-appbuilder
     #   flask-jwt-extended
-pynacl==1.5.0
+pynacl==1.6.2
     # via paramiko
 pyopenssl==25.1.0
     # via shillelagh


### PR DESCRIPTION
- Component: superset (rel/ODP-3.3.6.4-1, release 3.3.6.4)
- Library: pynacl → 1.6.2
- Tickets: OSV-23734
- Files: requirements/base.txt:pynacl==1.6.2×1