### PR TITLE
OSV-23735 - CVE - Bumped-up werkzeug to 3.1.6 to address CVE-2026-27199

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -427,7 +427,7 @@ wcwidth==0.2.13
     # via prompt-toolkit
 websocket-client==1.8.0
     # via selenium
-werkzeug==3.1.3
+werkzeug==3.1.6
     # via
     #   -r requirements/base.in
     #   flask


### PR DESCRIPTION
- Component: superset (rel/ODP-3.3.6.4-1, release 3.3.6.4)
- Library: werkzeug → 3.1.6
- Tickets: OSV-23735
- Files: requirements/base.txt:werkzeug==3.1.6×1