### PR TITLE
OSV-23703 - CVE - Bumped-up pyarrow to 17.0.0 to address CVE-2024-52338

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -277,7 +277,7 @@ prison==0.2.1
     # via flask-appbuilder
 prompt-toolkit==3.0.51
     # via click-repl
-pyarrow==16.1.0
+pyarrow==17.0.0
     # via apache-superset (pyproject.toml)
 pyasn1==0.6.1
     # via


### PR DESCRIPTION
- Component: superset (rel/ODP-3.3.6.4-1, release 3.3.6.4)
- Library: pyarrow → 17.0.0
- Tickets: OSV-23703
- Files: requirements/base.txt:pyarrow==17.0.0×1